### PR TITLE
Manage Undefined expresison Cron

### DIFF
--- a/src/cron-gen.component.js
+++ b/src/cron-gen.component.js
@@ -307,6 +307,11 @@ export class CronGenComponent {
             this.currentState = States.CLEAN;
         }
 
+         if(!cron){
+            // split() is undefined if cron expression is undefined.
+            return false;
+        }
+        
         const segments = cron.split(' ');
         if (segments.length === 6 || segments.length === 7) {
             const [seconds, minutes, hours, dayOfMonth, month, dayOfWeek] = segments;

--- a/src/cron-gen.service.js
+++ b/src/cron-gen.service.js
@@ -5,6 +5,9 @@ export class CronGenService {
     }
 
     isValid(cronFormat, expression) {
+        // toUpperCase() is undefined if expression is undefined
+        if(!expression)
+            return false;
         const formattedExpression = expression.toUpperCase();
         switch (cronFormat) {
             case 'quartz':


### PR DESCRIPTION
FIX an issue when the cron expression is undefined.

May occur :
- When initializing the generator with a null value.
- During the suppresion of the generator. (Digest)