### PR TITLE
FixBug:: Using 24h time option does not refresh the model correctly

### DIFF
--- a/src/templates/cron-gen-time-select.html
+++ b/src/templates/cron-gen-time-select.html
@@ -29,7 +29,7 @@
     </select>
     <select class="hour-types"
             name="{{namePrefix}}HourType"
-            ng-show="!$ctrl.use24HourTime"
+            ng-if="!$ctrl.use24HourTime"
             ng-disabled="$ctrl.isDisabled"
             ng-change="$ctrl.onChange()"
             ng-model="$ctrl.model.hourType"


### PR DESCRIPTION
I'm fixing this issue by using ng-if instead of ng-show since in the case where use24HourTime is true the value of hourtype is null,
which breaks the $digest because you use ng-required. 